### PR TITLE
Add support for user-provided proto codecs

### DIFF
--- a/src/composed_extension_codec.rs
+++ b/src/composed_extension_codec.rs
@@ -1,0 +1,89 @@
+use datafusion::error::DataFusionError;
+use datafusion::execution::FunctionRegistry;
+use datafusion::logical_expr::{AggregateUDF, ScalarUDF};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::SessionConfig;
+use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+use std::sync::Arc;
+
+// Taken from:
+// https://github.com/apache/datafusion/blob/0eebc0c7c0ffcd1514f5c6d0f8e2b6d0c69a07f5/datafusion-examples/examples/composed_extension_codec.rs#L236-L291
+
+/// A PhysicalExtensionCodec that tries one of multiple inner codecs
+/// until one works
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ComposedPhysicalExtensionCodec {
+    codecs: Vec<Arc<dyn PhysicalExtensionCodec>>,
+}
+
+impl ComposedPhysicalExtensionCodec {
+    pub(crate) fn push(&mut self, codec: impl PhysicalExtensionCodec + 'static) {
+        self.codecs.push(Arc::new(codec));
+    }
+
+    pub(crate) fn push_from_config(&mut self, config: &SessionConfig) {
+        if let Some(user_codec) = config.get_extension::<Arc<dyn PhysicalExtensionCodec>>() {
+            self.codecs.push(user_codec.as_ref().clone());
+        }
+    }
+
+    fn try_any<T>(
+        &self,
+        mut f: impl FnMut(&dyn PhysicalExtensionCodec) -> Result<T, DataFusionError>,
+    ) -> Result<T, DataFusionError> {
+        let mut last_err = None;
+        for codec in &self.codecs {
+            match f(codec.as_ref()) {
+                Ok(node) => return Ok(node),
+                Err(err) => last_err = Some(err),
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            DataFusionError::NotImplemented("Empty list of composed codecs".to_owned())
+        }))
+    }
+}
+
+impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+        registry: &dyn FunctionRegistry,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        self.try_any(|codec| codec.try_decode(buf, inputs, registry))
+    }
+
+    fn try_encode(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        buf: &mut Vec<u8>,
+    ) -> Result<(), DataFusionError> {
+        self.try_any(|codec| codec.try_encode(node.clone(), buf))
+    }
+
+    fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>, DataFusionError> {
+        self.try_any(|codec| codec.try_decode_udf(name, buf))
+    }
+
+    fn try_encode_udf(&self, node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<(), DataFusionError> {
+        self.try_any(|codec| codec.try_encode_udf(node, buf))
+    }
+
+    fn try_decode_udaf(
+        &self,
+        name: &str,
+        buf: &[u8],
+    ) -> Result<Arc<AggregateUDF>, DataFusionError> {
+        self.try_any(|codec| codec.try_decode_udaf(name, buf))
+    }
+
+    fn try_encode_udaf(
+        &self,
+        node: &AggregateUDF,
+        buf: &mut Vec<u8>,
+    ) -> Result<(), DataFusionError> {
+        self.try_any(|codec| codec.try_encode_udaf(node, buf))
+    }
+}

--- a/src/composed_extension_codec.rs
+++ b/src/composed_extension_codec.rs
@@ -1,47 +1,150 @@
+use datafusion::common::not_impl_err;
 use datafusion::error::DataFusionError;
 use datafusion::execution::FunctionRegistry;
-use datafusion::logical_expr::{AggregateUDF, ScalarUDF};
+use datafusion::logical_expr::{AggregateUDF, ScalarUDF, WindowUDF};
+use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionConfig;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+use std::fmt::Debug;
 use std::sync::Arc;
 
-// Taken from:
+
+// Idea taken from
 // https://github.com/apache/datafusion/blob/0eebc0c7c0ffcd1514f5c6d0f8e2b6d0c69a07f5/datafusion-examples/examples/composed_extension_codec.rs#L236-L291
+
+pub trait PhysicalExtensionCodecExt: Debug + Send + Sync {
+    fn try_decode(
+        &self,
+        _buf: &[u8],
+        _inputs: &[Arc<dyn ExecutionPlan>],
+        _registry: &dyn FunctionRegistry,
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        not_impl_err!("try_decode not implemented for {self:?}")
+    }
+
+    fn try_encode(
+        &self,
+        _node: Arc<dyn ExecutionPlan>,
+        _buf: &mut Vec<u8>,
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<()> {
+        not_impl_err!("try_encode not implemented for {self:?}")
+    }
+
+    fn try_decode_udf(
+        &self,
+        _name: &str,
+        _buf: &[u8],
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<Arc<ScalarUDF>> {
+        not_impl_err!("try_decode_udf not implemented for {self:?}")
+    }
+
+    fn try_encode_udf(
+        &self,
+        _node: &ScalarUDF,
+        _buf: &mut Vec<u8>,
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<()> {
+        Ok(())
+    }
+
+    fn try_decode_expr(
+        &self,
+        _buf: &[u8],
+        _inputs: &[Arc<dyn PhysicalExpr>],
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<Arc<dyn PhysicalExpr>> {
+        not_impl_err!("try_decode_expr not implemented for {self:?}")
+    }
+
+    fn try_encode_expr(
+        &self,
+        _node: &Arc<dyn PhysicalExpr>,
+        _buf: &mut Vec<u8>,
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<()> {
+        not_impl_err!("try_encode_expr not implemented for {self:?}")
+    }
+
+    fn try_decode_udaf(
+        &self,
+        _name: &str,
+        _buf: &[u8],
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<Arc<AggregateUDF>> {
+        not_impl_err!("try_decode_udaf not implemented for {self:?}")
+    }
+
+    fn try_encode_udaf(
+        &self,
+        _node: &AggregateUDF,
+        _buf: &mut Vec<u8>,
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<()> {
+        Ok(())
+    }
+
+    fn try_decode_udwf(
+        &self,
+        _name: &str,
+        _buf: &[u8],
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<Arc<WindowUDF>> {
+        not_impl_err!("try_decode_udwf not implemented for {self:?}")
+    }
+
+    fn try_encode_udwf(
+        &self,
+        _node: &WindowUDF,
+        _buf: &mut Vec<u8>,
+        _codec: &dyn PhysicalExtensionCodec
+    ) -> datafusion::common::Result<()> {
+        Ok(())
+    }
+}
 
 /// A PhysicalExtensionCodec that tries one of multiple inner codecs
 /// until one works
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ComposedPhysicalExtensionCodec {
-    codecs: Vec<Arc<dyn PhysicalExtensionCodec>>,
+    codecs: Vec<Arc<dyn PhysicalExtensionCodecExt>>,
 }
 
 impl ComposedPhysicalExtensionCodec {
-    pub(crate) fn push(&mut self, codec: impl PhysicalExtensionCodec + 'static) {
+    pub(crate) fn push(&mut self, codec: impl PhysicalExtensionCodecExt + 'static) {
         self.codecs.push(Arc::new(codec));
     }
 
     pub(crate) fn push_from_config(&mut self, config: &SessionConfig) {
-        if let Some(user_codec) = config.get_extension::<Arc<dyn PhysicalExtensionCodec>>() {
+        if let Some(user_codec) = config.get_extension::<Arc<dyn PhysicalExtensionCodecExt>>() {
             self.codecs.push(user_codec.as_ref().clone());
         }
     }
 
     fn try_any<T>(
         &self,
-        mut f: impl FnMut(&dyn PhysicalExtensionCodec) -> Result<T, DataFusionError>,
+        mut f: impl FnMut(&dyn PhysicalExtensionCodecExt) -> Result<T, DataFusionError>,
     ) -> Result<T, DataFusionError> {
-        let mut last_err = None;
+        let mut errs = vec![];
         for codec in &self.codecs {
             match f(codec.as_ref()) {
                 Ok(node) => return Ok(node),
-                Err(err) => last_err = Some(err),
+                Err(err) => errs.push(err),
             }
         }
 
-        Err(last_err.unwrap_or_else(|| {
-            DataFusionError::NotImplemented("Empty list of composed codecs".to_owned())
-        }))
+        if errs.is_empty() {
+            return not_impl_err!("Empty list of composed codecs");
+        }
+
+        let mut msg = "None of the provided PhysicalExtensionCodec worked:".to_string();
+        for err in &errs {
+            msg += &format!("\n    {err}");
+        }
+        not_impl_err!("{msg}")
     }
 }
 
@@ -52,7 +155,7 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         inputs: &[Arc<dyn ExecutionPlan>],
         registry: &dyn FunctionRegistry,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        self.try_any(|codec| codec.try_decode(buf, inputs, registry))
+        self.try_any(|codec| codec.try_decode(buf, inputs, registry, self))
     }
 
     fn try_encode(
@@ -60,15 +163,15 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         node: Arc<dyn ExecutionPlan>,
         buf: &mut Vec<u8>,
     ) -> Result<(), DataFusionError> {
-        self.try_any(|codec| codec.try_encode(node.clone(), buf))
+        self.try_any(|codec| codec.try_encode(node.clone(), buf, self))
     }
 
     fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>, DataFusionError> {
-        self.try_any(|codec| codec.try_decode_udf(name, buf))
+        self.try_any(|codec| codec.try_decode_udf(name, buf, self))
     }
 
     fn try_encode_udf(&self, node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<(), DataFusionError> {
-        self.try_any(|codec| codec.try_encode_udf(node, buf))
+        self.try_any(|codec| codec.try_encode_udf(node, buf, self))
     }
 
     fn try_decode_udaf(
@@ -76,7 +179,7 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         name: &str,
         buf: &[u8],
     ) -> Result<Arc<AggregateUDF>, DataFusionError> {
-        self.try_any(|codec| codec.try_decode_udaf(name, buf))
+        self.try_any(|codec| codec.try_decode_udaf(name, buf, self))
     }
 
     fn try_encode_udaf(
@@ -84,6 +187,6 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         node: &AggregateUDF,
         buf: &mut Vec<u8>,
     ) -> Result<(), DataFusionError> {
-        self.try_any(|codec| codec.try_encode_udaf(node, buf))
+        self.try_any(|codec| codec.try_encode_udaf(node, buf, self))
     }
 }

--- a/src/composed_extension_codec.rs
+++ b/src/composed_extension_codec.rs
@@ -1,189 +1,71 @@
 use datafusion::common::not_impl_err;
 use datafusion::error::DataFusionError;
 use datafusion::execution::FunctionRegistry;
-use datafusion::logical_expr::{AggregateUDF, ScalarUDF, WindowUDF};
-use datafusion::physical_expr::PhysicalExpr;
+use datafusion::logical_expr::{AggregateUDF, ScalarUDF};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionConfig;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-
 // Idea taken from
 // https://github.com/apache/datafusion/blob/0eebc0c7c0ffcd1514f5c6d0f8e2b6d0c69a07f5/datafusion-examples/examples/composed_extension_codec.rs#L236-L291
 
-/// Trait that mimics DataFusion's [PhysicalExtensionCodec] where each method accepts a last
-/// argument with a [PhysicalExtensionCodec]. 
-///
-/// This allows composing multiple [PhysicalExtensionCodecExt] into one single 
-/// [ComposedPhysicalExtensionCodec] that can be used as a central [PhysicalExtensionCodec]
-/// implementation that is capable of encoding/decoding not only this project's specific
-/// plans, but also any other user-provided plan.
-/// 
-/// [PhysicalExtensionCodecExt] implementations will be able to pass down this 
-/// centralized [PhysicalExtensionCodec] so that children can also make use of all the codecs 
-/// available in it for encoding/decoding themselves and their children.
-pub trait PhysicalExtensionCodecExt: Debug + Send + Sync {
-    /// Same as [PhysicalExtensionCodec::try_decode], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_decode(
-        &self,
-        _buf: &[u8],
-        _inputs: &[Arc<dyn ExecutionPlan>],
-        _registry: &dyn FunctionRegistry,
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        not_impl_err!("try_decode not implemented for {self:?}")
-    }
-
-    /// Same as [PhysicalExtensionCodec::try_encode], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_encode(
-        &self,
-        _node: Arc<dyn ExecutionPlan>,
-        _buf: &mut Vec<u8>,
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<()> {
-        not_impl_err!("try_encode not implemented for {self:?}")
-    }
-
-    /// Same as [PhysicalExtensionCodec::try_decode_udf], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_decode_udf(
-        &self,
-        _name: &str,
-        _buf: &[u8],
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<Arc<ScalarUDF>> {
-        not_impl_err!("try_decode_udf not implemented for {self:?}")
-    }
-
-    /// Same as [PhysicalExtensionCodec::try_encode_udf], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_encode_udf(
-        &self,
-        _node: &ScalarUDF,
-        _buf: &mut Vec<u8>,
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<()> {
-        Ok(())
-    }
-
-    /// Same as [PhysicalExtensionCodec::try_decode_expr], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_decode_expr(
-        &self,
-        _buf: &[u8],
-        _inputs: &[Arc<dyn PhysicalExpr>],
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<Arc<dyn PhysicalExpr>> {
-        not_impl_err!("try_decode_expr not implemented for {self:?}")
-    }
-
-    /// Same as [PhysicalExtensionCodec::try_encode_expr], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_encode_expr(
-        &self,
-        _node: &Arc<dyn PhysicalExpr>,
-        _buf: &mut Vec<u8>,
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<()> {
-        not_impl_err!("try_encode_expr not implemented for {self:?}")
-    }
-
-    /// Same as [PhysicalExtensionCodec::try_decode_udaf], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_decode_udaf(
-        &self,
-        _name: &str,
-        _buf: &[u8],
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<Arc<AggregateUDF>> {
-        not_impl_err!("try_decode_udaf not implemented for {self:?}")
-    }
-
-    /// Same as [PhysicalExtensionCodec::try_encode_udaf], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_encode_udaf(
-        &self,
-        _node: &AggregateUDF,
-        _buf: &mut Vec<u8>,
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<()> {
-        Ok(())
-    }
-
-    /// Same as [PhysicalExtensionCodec::try_decode_udwf], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_decode_udwf(
-        &self,
-        _name: &str,
-        _buf: &[u8],
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<Arc<WindowUDF>> {
-        not_impl_err!("try_decode_udwf not implemented for {self:?}")
-    }
-
-    /// Same as [PhysicalExtensionCodec::try_encode_udwf], but accepting a centralized [PhysicalExtensionCodec]
-    /// as its last argument.
-    fn try_encode_udwf(
-        &self,
-        _node: &WindowUDF,
-        _buf: &mut Vec<u8>,
-        _codec: &dyn PhysicalExtensionCodec
-    ) -> datafusion::common::Result<()> {
-        Ok(())
-    }
-}
-
-/// A [PhysicalExtensionCodec] that holds multiple [PhysicalExtensionCodecExt] and tries them
+/// A [PhysicalExtensionCodec] that holds multiple [PhysicalExtensionCodec] and tries them
 /// sequentially until one works.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ComposedPhysicalExtensionCodec {
-    codecs: Vec<Arc<dyn PhysicalExtensionCodecExt>>,
+    codecs: Vec<Arc<dyn PhysicalExtensionCodec>>,
 }
 
 impl ComposedPhysicalExtensionCodec {
-    /// Adds a new [PhysicalExtensionCodecExt] to the list. These codecs will be tried
+    /// Adds a new [PhysicalExtensionCodec] to the list. These codecs will be tried
     /// sequentially until one works.
-    pub(crate) fn push(&mut self, codec: impl PhysicalExtensionCodecExt + 'static) {
+    pub(crate) fn push(&mut self, codec: impl PhysicalExtensionCodec + 'static) {
         self.codecs.push(Arc::new(codec));
     }
 
-    /// Adds a new [PhysicalExtensionCodecExt] from DataFusion's [SessionConfig] extensions.
-    /// 
-    /// If users have a custom [PhysicalExtensionCodecExt] for their own nodes, they should
-    /// populate the config extensions with a [PhysicalExtensionCodecExt] so that we can use
+    /// Adds a new [PhysicalExtensionCodec] from DataFusion's [SessionConfig] extensions.
+    ///
+    /// If users have a custom [PhysicalExtensionCodec] for their own nodes, they should
+    /// populate the config extensions with a [PhysicalExtensionCodec] so that we can use
     /// it while encoding/decoding plans to/from protobuf.
-    /// 
+    ///
     /// Example:
     /// ```rust
     /// # use std::sync::Arc;
+    /// # use datafusion::execution::FunctionRegistry;
+    /// # use datafusion::physical_plan::ExecutionPlan;
     /// # use datafusion::prelude::SessionConfig;
-    /// # use datafusion_distributed_experiment::PhysicalExtensionCodecExt;
+    /// # use datafusion_proto::physical_plan::PhysicalExtensionCodec;
     ///
     /// #[derive(Debug)]
     /// struct CustomUserCodec {}
     ///
-    /// impl PhysicalExtensionCodecExt for CustomUserCodec {
-    ///     // custom encoding/decoding logic
+    /// impl PhysicalExtensionCodec for CustomUserCodec {
+    ///     fn try_decode(&self, buf: &[u8], inputs: &[Arc<dyn ExecutionPlan>], registry: &dyn FunctionRegistry) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+    ///         todo!()
+    ///     }
+    ///
+    ///     fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> datafusion::common::Result<()> {
+    ///         todo!()
+    ///     }
     /// }
     ///
     /// let mut config = SessionConfig::new();
     ///
-    /// let codec: Arc<dyn PhysicalExtensionCodecExt> = Arc::new(CustomUserCodec {});
+    /// let codec: Arc<dyn PhysicalExtensionCodec> = Arc::new(CustomUserCodec {});
     /// config.set_extension(Arc::new(codec));
     /// ```
     pub(crate) fn push_from_config(&mut self, config: &SessionConfig) {
-        if let Some(user_codec) = config.get_extension::<Arc<dyn PhysicalExtensionCodecExt>>() {
+        if let Some(user_codec) = config.get_extension::<Arc<dyn PhysicalExtensionCodec>>() {
             self.codecs.push(user_codec.as_ref().clone());
         }
     }
 
     fn try_any<T>(
         &self,
-        mut f: impl FnMut(&dyn PhysicalExtensionCodecExt) -> Result<T, DataFusionError>,
+        mut f: impl FnMut(&dyn PhysicalExtensionCodec) -> Result<T, DataFusionError>,
     ) -> Result<T, DataFusionError> {
         let mut errs = vec![];
         for codec in &self.codecs {
@@ -212,7 +94,7 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         inputs: &[Arc<dyn ExecutionPlan>],
         registry: &dyn FunctionRegistry,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        self.try_any(|codec| codec.try_decode(buf, inputs, registry, self))
+        self.try_any(|codec| codec.try_decode(buf, inputs, registry))
     }
 
     fn try_encode(
@@ -220,15 +102,15 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         node: Arc<dyn ExecutionPlan>,
         buf: &mut Vec<u8>,
     ) -> Result<(), DataFusionError> {
-        self.try_any(|codec| codec.try_encode(node.clone(), buf, self))
+        self.try_any(|codec| codec.try_encode(node.clone(), buf))
     }
 
     fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>, DataFusionError> {
-        self.try_any(|codec| codec.try_decode_udf(name, buf, self))
+        self.try_any(|codec| codec.try_decode_udf(name, buf))
     }
 
     fn try_encode_udf(&self, node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<(), DataFusionError> {
-        self.try_any(|codec| codec.try_encode_udf(node, buf, self))
+        self.try_any(|codec| codec.try_encode_udf(node, buf))
     }
 
     fn try_decode_udaf(
@@ -236,7 +118,7 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         name: &str,
         buf: &[u8],
     ) -> Result<Arc<AggregateUDF>, DataFusionError> {
-        self.try_any(|codec| codec.try_decode_udaf(name, buf, self))
+        self.try_any(|codec| codec.try_decode_udaf(name, buf))
     }
 
     fn try_encode_udaf(
@@ -244,6 +126,6 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
         node: &AggregateUDF,
         buf: &mut Vec<u8>,
     ) -> Result<(), DataFusionError> {
-        self.try_any(|codec| codec.try_encode_udaf(node, buf, self))
+        self.try_any(|codec| codec.try_encode_udaf(node, buf))
     }
 }

--- a/src/flight_service/do_get.rs
+++ b/src/flight_service/do_get.rs
@@ -99,7 +99,7 @@ impl ArrowFlightEndpoint {
         };
 
         let mut codec = ComposedPhysicalExtensionCodec::default();
-        codec.push(ArrowFlightReadExecProtoCodec::new(&self.runtime));
+        codec.push(ArrowFlightReadExecProtoCodec);
         codec.push_from_config(state.config());
 
         let plan = plan_proto

--- a/src/flight_service/do_get.rs
+++ b/src/flight_service/do_get.rs
@@ -99,8 +99,8 @@ impl ArrowFlightEndpoint {
         };
 
         let mut codec = ComposedPhysicalExtensionCodec::default();
-        codec.push_from_config(state.config());
         codec.push(ArrowFlightReadExecProtoCodec::new(&self.runtime));
+        codec.push_from_config(state.config());
 
         let plan = plan_proto
             .try_into_physical_plan(function_registry, &self.runtime, &codec)

--- a/src/flight_service/do_get.rs
+++ b/src/flight_service/do_get.rs
@@ -99,8 +99,8 @@ impl ArrowFlightEndpoint {
         };
 
         let mut codec = ComposedPhysicalExtensionCodec::default();
-        codec.push(ArrowFlightReadExecProtoCodec::new(&self.runtime));
         codec.push_from_config(state.config());
+        codec.push(ArrowFlightReadExecProtoCodec::new(&self.runtime));
 
         let plan = plan_proto
             .try_into_physical_plan(function_registry, &self.runtime, &codec)

--- a/src/flight_service/mod.rs
+++ b/src/flight_service/mod.rs
@@ -2,8 +2,10 @@ mod do_get;
 mod do_put;
 mod service;
 mod stream_partitioner_registry;
+mod session_builder;
 
 pub(crate) use do_get::DoGet;
 pub(crate) use do_put::DoPut;
 
 pub use service::ArrowFlightEndpoint;
+pub use session_builder::SessionBuilder;

--- a/src/flight_service/session_builder.rs
+++ b/src/flight_service/session_builder.rs
@@ -13,24 +13,30 @@ pub trait SessionBuilder {
     ///
     /// # use std::sync::Arc;
     /// # use datafusion::execution::runtime_env::RuntimeEnv;
-    /// # use datafusion::execution::SessionStateBuilder;
-    /// # use datafusion_distributed_experiment::{PhysicalExtensionCodecExt, SessionBuilder};
+    /// # use datafusion::execution::{FunctionRegistry, SessionStateBuilder};
+    /// # use datafusion::physical_plan::ExecutionPlan;
+    /// # use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+    /// # use datafusion_distributed_experiment::{SessionBuilder};
     ///
     /// #[derive(Debug)]
-    /// struct CustomExecCodec {
-    ///   runtime: Arc<RuntimeEnv>,
+    /// struct CustomExecCodec;
+    ///
+    /// impl PhysicalExtensionCodec for CustomExecCodec {
+    ///     fn try_decode(&self, buf: &[u8], inputs: &[Arc<dyn ExecutionPlan>], registry: &dyn FunctionRegistry) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+    ///         todo!()
+    ///     }
+    ///
+    ///     fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> datafusion::common::Result<()> {
+    ///         todo!()
+    ///     }
     /// }
     ///
     /// #[derive(Clone)]
     /// struct CustomSessionBuilder;
     /// impl SessionBuilder for CustomSessionBuilder {
     ///     fn on_new_session(&self, mut builder: SessionStateBuilder) -> SessionStateBuilder {
-    ///         let runtime = builder.runtime_env().get_or_insert_default();
     ///         let config = builder.config().get_or_insert_default();
-    ///
-    ///         let codec: Arc<dyn PhysicalExtensionCodecExt> = Arc::new(CustomExecCodec {
-    ///             runtime: runtime.clone()
-    ///         });
+    ///         let codec: Arc<dyn PhysicalExtensionCodec> = Arc::new(CustomExecCodec);
     ///         config.set_extension(Arc::new(codec));
     ///         builder
     ///     }

--- a/src/flight_service/session_builder.rs
+++ b/src/flight_service/session_builder.rs
@@ -1,9 +1,46 @@
 use datafusion::execution::SessionStateBuilder;
 
+/// Trait called by the Arrow Flight endpoint that handles distributed parts of a DataFusion
+/// plan for building a DataFusion's [datafusion::prelude::SessionContext].
 pub trait SessionBuilder {
+    /// Takes a [SessionStateBuilder] and adds whatever is necessary for it to work, like
+    /// custom extension codecs, custom physical optimization rules, UDFs, UDAFs, config
+    /// extensions, etc...
+    ///
+    /// Example: adding some custom extension plan codecs
+    ///
+    /// ```rust
+    ///
+    /// # use std::sync::Arc;
+    /// # use datafusion::execution::runtime_env::RuntimeEnv;
+    /// # use datafusion::execution::SessionStateBuilder;
+    /// # use datafusion_distributed_experiment::{PhysicalExtensionCodecExt, SessionBuilder};
+    ///
+    /// #[derive(Debug)]
+    /// struct CustomExecCodec {
+    ///   runtime: Arc<RuntimeEnv>,
+    /// }
+    ///
+    /// #[derive(Clone)]
+    /// struct CustomSessionBuilder;
+    /// impl SessionBuilder for CustomSessionBuilder {
+    ///     fn on_new_session(&self, mut builder: SessionStateBuilder) -> SessionStateBuilder {
+    ///         let runtime = builder.runtime_env().get_or_insert_default();
+    ///         let config = builder.config().get_or_insert_default();
+    ///
+    ///         let codec: Arc<dyn PhysicalExtensionCodecExt> = Arc::new(CustomExecCodec {
+    ///             runtime: runtime.clone()
+    ///         });
+    ///         config.set_extension(Arc::new(codec));
+    ///         builder
+    ///     }
+    /// }
+    /// ```
     fn on_new_session(&self, builder: SessionStateBuilder) -> SessionStateBuilder;
 }
 
+/// Noop implementation of the [SessionBuilder]. Used by default if no [SessionBuilder] is provided
+/// while building the Arrow Flight endpoint.
 pub struct NoopSessionBuilder;
 
 impl SessionBuilder for NoopSessionBuilder {

--- a/src/flight_service/session_builder.rs
+++ b/src/flight_service/session_builder.rs
@@ -1,0 +1,13 @@
+use datafusion::execution::SessionStateBuilder;
+
+pub trait SessionBuilder {
+    fn on_new_session(&self, builder: SessionStateBuilder) -> SessionStateBuilder;
+}
+
+pub struct NoopSessionBuilder;
+
+impl SessionBuilder for NoopSessionBuilder {
+    fn on_new_session(&self, builder: SessionStateBuilder) -> SessionStateBuilder {
+        builder
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,5 @@ pub mod test_utils;
 pub use channel_manager::{
     ArrowFlightChannel, BoxCloneSyncChannel, ChannelManager, ChannelResolver,
 };
-pub use composed_extension_codec::PhysicalExtensionCodecExt;
 pub use flight_service::{ArrowFlightEndpoint, SessionBuilder};
 pub use plan::ArrowFlightReadExec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@ mod channel_manager;
 mod flight_service;
 mod plan;
 mod stage_delegation;
-mod test_utils;
+#[cfg(test)]
+pub mod test_utils;
 mod composed_extension_codec;
 
 pub use plan::ArrowFlightReadExec;
-pub use flight_service::ArrowFlightEndpoint;
+pub use flight_service::{ArrowFlightEndpoint, SessionBuilder};
 pub use channel_manager::{ChannelResolver, ArrowFlightChannel, BoxCloneSyncChannel, ChannelManager};
+pub use composed_extension_codec::{PhysicalExtensionCodecExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod flight_service;
 mod plan;
 mod stage_delegation;
 mod test_utils;
+mod composed_extension_codec;
 
 pub use plan::ArrowFlightReadExec;
 pub use flight_service::ArrowFlightEndpoint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 mod channel_manager;
+mod composed_extension_codec;
 mod flight_service;
 mod plan;
 mod stage_delegation;
 #[cfg(test)]
 pub mod test_utils;
-mod composed_extension_codec;
 
-pub use plan::ArrowFlightReadExec;
+pub use channel_manager::{
+    ArrowFlightChannel, BoxCloneSyncChannel, ChannelManager, ChannelResolver,
+};
+pub use composed_extension_codec::PhysicalExtensionCodecExt;
 pub use flight_service::{ArrowFlightEndpoint, SessionBuilder};
-pub use channel_manager::{ChannelResolver, ArrowFlightChannel, BoxCloneSyncChannel, ChannelManager};
-pub use composed_extension_codec::{PhysicalExtensionCodecExt};
+pub use plan::ArrowFlightReadExec;

--- a/src/plan/arrow_flight_read.rs
+++ b/src/plan/arrow_flight_read.rs
@@ -110,7 +110,6 @@ impl ExecutionPlan for ArrowFlightReadExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> datafusion::common::Result<SendableRecordBatchStream> {
-        let runtime = context.runtime_env();
         let partitioning = self.properties.partitioning.clone();
 
         let channel_manager = ChannelManager::try_from_session(context.session_config())?;
@@ -173,8 +172,8 @@ impl ExecutionPlan for ArrowFlightReadExec {
             }
 
             let mut codec = ComposedPhysicalExtensionCodec::default();
-            codec.push(ArrowFlightReadExecProtoCodec::new(&context.runtime_env()));
             codec.push_from_config(context.session_config());
+            codec.push(ArrowFlightReadExecProtoCodec::new(&context.runtime_env()));
 
             let ticket = DoGet::new_remote_plan_exec_ticket(
                 plan,

--- a/src/plan/arrow_flight_read.rs
+++ b/src/plan/arrow_flight_read.rs
@@ -172,7 +172,7 @@ impl ExecutionPlan for ArrowFlightReadExec {
             }
 
             let mut codec = ComposedPhysicalExtensionCodec::default();
-            codec.push(ArrowFlightReadExecProtoCodec::new(&context.runtime_env()));
+            codec.push(ArrowFlightReadExecProtoCodec);
             codec.push_from_config(context.session_config());
 
             let ticket = DoGet::new_remote_plan_exec_ticket(

--- a/src/plan/arrow_flight_read.rs
+++ b/src/plan/arrow_flight_read.rs
@@ -172,8 +172,8 @@ impl ExecutionPlan for ArrowFlightReadExec {
             }
 
             let mut codec = ComposedPhysicalExtensionCodec::default();
-            codec.push_from_config(context.session_config());
             codec.push(ArrowFlightReadExecProtoCodec::new(&context.runtime_env()));
+            codec.push_from_config(context.session_config());
 
             let ticket = DoGet::new_remote_plan_exec_ticket(
                 plan,

--- a/src/plan/arrow_flight_read_proto.rs
+++ b/src/plan/arrow_flight_read_proto.rs
@@ -1,54 +1,71 @@
 use crate::plan::arrow_flight_read::ArrowFlightReadExec;
-use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::execution::FunctionRegistry;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::physical_plan::from_proto::parse_protobuf_partitioning;
 use datafusion_proto::physical_plan::to_proto::serialize_partitioning;
-use datafusion_proto::physical_plan::{AsExecutionPlan, PhysicalExtensionCodec};
+use datafusion_proto::physical_plan::{DefaultPhysicalExtensionCodec, PhysicalExtensionCodec};
 use datafusion_proto::protobuf;
-use datafusion_proto::protobuf::{proto_error, PhysicalPlanNode};
-use prost::bytes::BufMut;
+use datafusion_proto::protobuf::proto_error;
 use prost::Message;
 use std::sync::Arc;
-use crate::composed_extension_codec::PhysicalExtensionCodecExt;
 
 /// DataFusion [PhysicalExtensionCodec] implementation that allows sending and receiving
 /// [ArrowFlightReadExecProto] over the wire.
 #[derive(Debug)]
-pub struct ArrowFlightReadExecProtoCodec {
-    runtime: Arc<RuntimeEnv>,
-}
+pub struct ArrowFlightReadExecProtoCodec;
 
-impl ArrowFlightReadExecProtoCodec {
-    pub fn new(runtime: &Arc<RuntimeEnv>) -> Self {
-        Self {
-            runtime: Arc::clone(runtime),
-        }
-    }
-}
-
-impl PhysicalExtensionCodecExt for ArrowFlightReadExecProtoCodec {
+impl PhysicalExtensionCodec for ArrowFlightReadExecProtoCodec {
     fn try_decode(
         &self,
         buf: &[u8],
-        _inputs: &[Arc<dyn ExecutionPlan>], // TODO: why would I want this here
+        inputs: &[Arc<dyn ExecutionPlan>],
         registry: &dyn FunctionRegistry,
-        codec: &dyn PhysicalExtensionCodec
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        ArrowFlightReadExecProto::try_decode(buf)?.try_into_physical_plan(
+        let ArrowFlightReadExecProto { partitioning } =
+            ArrowFlightReadExecProto::decode(buf).map_err(|err| proto_error(format!("{err}")))?;
+
+        if inputs.len() != 1 {
+            return Err(proto_error(format!(
+                "Expected exactly 1 input, but got {}",
+                inputs.len()
+            )));
+        }
+
+        let Some(partitioning) = parse_protobuf_partitioning(
+            partitioning.as_ref(),
             registry,
-            &self.runtime,
-            codec,
-        )
+            &inputs[0].schema(),
+            &DefaultPhysicalExtensionCodec {},
+        )?
+        else {
+            return Err(proto_error("Partitioning not specified"));
+        };
+        Ok(Arc::new(ArrowFlightReadExec::new(
+            inputs[0].clone(),
+            partitioning,
+        )))
     }
 
     fn try_encode(
         &self,
         node: Arc<dyn ExecutionPlan>,
         buf: &mut Vec<u8>,
-        codec: &dyn PhysicalExtensionCodec
     ) -> datafusion::common::Result<()> {
-        ArrowFlightReadExecProto::try_from_physical_plan(node, codec)?.try_encode(buf)
+        let Some(node) = node.as_any().downcast_ref::<ArrowFlightReadExec>() else {
+            return Err(proto_error(format!(
+                "Expected ArrowFlightReadExec, but got {}",
+                node.name()
+            )));
+        };
+
+        ArrowFlightReadExecProto {
+            partitioning: Some(serialize_partitioning(
+                &node.properties().partitioning,
+                &DefaultPhysicalExtensionCodec {},
+            )?),
+        }
+        .encode(buf)
+        .map_err(|err| proto_error(format!("{err}")))
     }
 }
 
@@ -57,82 +74,6 @@ impl PhysicalExtensionCodecExt for ArrowFlightReadExecProtoCodec {
 /// to send them over the wire.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArrowFlightReadExecProto {
-    #[prost(message, optional, boxed, tag = "1")]
-    child: Option<Box<PhysicalPlanNode>>,
     #[prost(message, optional, tag = "2")]
     partitioning: Option<protobuf::Partitioning>,
-}
-
-impl AsExecutionPlan for ArrowFlightReadExecProto {
-    fn try_decode(buf: &[u8]) -> datafusion::common::Result<Self>
-    where
-        Self: Sized,
-    {
-        ArrowFlightReadExecProto::decode(buf).map_err(|err| proto_error(format!("{err}")))
-    }
-
-    fn try_encode<B>(&self, buf: &mut B) -> datafusion::common::Result<()>
-    where
-        B: BufMut,
-        Self: Sized,
-    {
-        self.encode(buf)
-            .map_err(|err| proto_error(format!("{err}")))
-    }
-
-    fn try_into_physical_plan(
-        &self,
-        registry: &dyn FunctionRegistry,
-        runtime: &RuntimeEnv,
-        extension_codec: &dyn PhysicalExtensionCodec,
-    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        let Some(child) = &self.child else {
-            return Err(proto_error("ArrowFlightReadExecProto must have a child"));
-        };
-
-        let plan = child.try_into_physical_plan(registry, runtime, extension_codec)?;
-        let Some(partitioning) = parse_protobuf_partitioning(
-            self.partitioning.as_ref(),
-            registry,
-            &plan.schema(),
-            extension_codec,
-        )?
-        else {
-            return Err(proto_error(
-                "ArrowFlightReadExecProto is missing the partitioning scheme",
-            ));
-        };
-
-        Ok(Arc::new(ArrowFlightReadExec::new(plan, partitioning)))
-    }
-
-    fn try_from_physical_plan(
-        plan: Arc<dyn ExecutionPlan>,
-        extension_codec: &dyn PhysicalExtensionCodec,
-    ) -> datafusion::common::Result<Self>
-    where
-        Self: Sized,
-    {
-        let Some(node) = plan.as_any().downcast_ref::<ArrowFlightReadExec>() else {
-            return Err(proto_error(format!("Expected ArrowFlightReadExec, but got {}", plan.name())));
-        };
-        if node.children().len() != 1 {
-            return Err(proto_error(format!(
-                "Expected ArrowFlightReadExec to have exactly 1 child, got {}",
-                node.children().len()
-            )));
-        }
-        let child = node.children()[0];
-
-        Ok(Self {
-            partitioning: Some(serialize_partitioning(
-                &node.properties().partitioning,
-                extension_codec,
-            )?),
-            child: Some(Box::new(PhysicalPlanNode::try_from_physical_plan(
-                Arc::clone(child),
-                extension_codec,
-            )?)),
-        })
-    }
 }

--- a/tests/common/localhost.rs
+++ b/tests/common/localhost.rs
@@ -2,9 +2,11 @@ use arrow_flight::flight_service_server::FlightServiceServer;
 use async_trait::async_trait;
 use datafusion::common::runtime::JoinSet;
 use datafusion::common::DataFusionError;
+use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::SessionContext;
 use datafusion_distributed_experiment::{
     ArrowFlightChannel, ArrowFlightEndpoint, BoxCloneSyncChannel, ChannelManager, ChannelResolver,
+    SessionBuilder,
 };
 use std::error::Error;
 use std::sync::atomic::AtomicUsize;
@@ -13,19 +15,35 @@ use std::time::Duration;
 use tonic::transport::{Channel, Server};
 use url::Url;
 
-pub async fn start_localhost_context<N: TryInto<u16>, I: IntoIterator<Item = N>>(
+#[derive(Debug, Clone)]
+pub struct NoopSessionBuilder;
+impl SessionBuilder for NoopSessionBuilder {
+    fn on_new_session(&self, builder: SessionStateBuilder) -> SessionStateBuilder {
+        builder
+    }
+}
+
+pub async fn start_localhost_context<N, I, B>(
     ports: I,
+    session_builder: B,
 ) -> (SessionContext, JoinSet<()>)
 where
     N::Error: std::fmt::Debug,
+    N: TryInto<u16>,
+    I: IntoIterator<Item = N>,
+    B: SessionBuilder + Send + Sync + 'static,
+    B: Clone,
 {
     let ports: Vec<u16> = ports.into_iter().map(|x| x.try_into().unwrap()).collect();
     let channel_resolver = LocalHostChannelResolver::new(ports.clone());
     let mut join_set = JoinSet::new();
     for port in ports {
         let channel_resolver = channel_resolver.clone();
+        let session_builder = session_builder.clone();
         join_set.spawn(async move {
-            spawn_flight_service(channel_resolver, port).await.unwrap();
+            spawn_flight_service(channel_resolver, session_builder, port)
+                .await
+                .unwrap();
         });
     }
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -88,9 +106,11 @@ impl ChannelResolver for LocalHostChannelResolver {
 
 pub async fn spawn_flight_service(
     channel_resolver: impl ChannelResolver + Send + Sync + 'static,
+    session_builder: impl SessionBuilder + Send + Sync + 'static,
     port: u16,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    let endpoint = ArrowFlightEndpoint::new(channel_resolver);
+    let mut endpoint = ArrowFlightEndpoint::new(channel_resolver);
+    endpoint.with_session_builder(session_builder);
     Ok(Server::builder()
         .add_service(FlightServiceServer::new(endpoint))
         .serve(format!("127.0.0.1:{port}").parse()?)

--- a/tests/custom_extension_codec.rs
+++ b/tests/custom_extension_codec.rs
@@ -10,7 +10,6 @@ mod tests {
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::arrow::util::pretty::pretty_format_batches;
     use datafusion::error::DataFusionError;
-    use datafusion::execution::runtime_env::RuntimeEnv;
     use datafusion::execution::{
         FunctionRegistry, SendableRecordBatchStream, SessionStateBuilder, TaskContext,
     };
@@ -21,20 +20,21 @@ mod tests {
     };
     use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
     use datafusion::physical_plan::filter::FilterExec;
+    use datafusion::physical_plan::repartition::RepartitionExec;
     use datafusion::physical_plan::sorts::sort::SortExec;
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-    use datafusion::physical_plan::{displayable, execute_stream, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
-    use datafusion_distributed_experiment::{ArrowFlightReadExec, PhysicalExtensionCodecExt, SessionBuilder};
-    use datafusion_proto::physical_plan::{AsExecutionPlan, PhysicalExtensionCodec};
+    use datafusion::physical_plan::{
+        displayable, execute_stream, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+    };
+    use datafusion_distributed_experiment::{ArrowFlightReadExec, SessionBuilder};
+    use datafusion_proto::physical_plan::PhysicalExtensionCodec;
     use datafusion_proto::protobuf::proto_error;
     use futures::{stream, TryStreamExt};
     use insta::assert_snapshot;
-    use prost::bytes::BufMut;
     use prost::Message;
     use std::any::Any;
     use std::fmt::Formatter;
     use std::sync::Arc;
-    use datafusion::physical_plan::repartition::RepartitionExec;
 
     #[tokio::test]
     async fn custom_extension_codec() -> Result<(), Box<dyn std::error::Error>> {
@@ -42,9 +42,7 @@ mod tests {
         struct CustomSessionBuilder;
         impl SessionBuilder for CustomSessionBuilder {
             fn on_new_session(&self, mut builder: SessionStateBuilder) -> SessionStateBuilder {
-                let runtime_env = builder.runtime_env().get_or_insert_default();
-                let codec: Arc<dyn PhysicalExtensionCodecExt> =
-                    Arc::new(Int64ListExecCodec::new(runtime_env.clone()));
+                let codec: Arc<dyn PhysicalExtensionCodec> = Arc::new(Int64ListExecCodec);
                 let config = builder.config().get_or_insert_default();
                 config.set_extension(Arc::new(codec));
                 builder
@@ -54,8 +52,7 @@ mod tests {
         let (ctx, _guard) =
             start_localhost_context([50050, 50051, 50052], CustomSessionBuilder).await;
 
-        let codec: Arc<dyn PhysicalExtensionCodecExt> =
-            Arc::new(Int64ListExecCodec::new(ctx.runtime_env()));
+        let codec: Arc<dyn PhysicalExtensionCodec> = Arc::new(Int64ListExecCodec);
         ctx.state_ref()
             .write()
             .config_mut()
@@ -113,8 +110,7 @@ mod tests {
     }
 
     fn build_plan(distributed: bool) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let mut plan: Arc<dyn ExecutionPlan> =
-            Arc::new(Int64ListExec::new(vec![1, 2, 3, 4, 5, 6]));
+        let mut plan: Arc<dyn ExecutionPlan> = Arc::new(Int64ListExec::new(vec![1, 2, 3, 4, 5, 6]));
 
         plan = Arc::new(FilterExec::try_new(
             Arc::new(BinaryExpr::new(
@@ -231,40 +227,7 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct Int64ListExecCodec {
-        runtime: Arc<RuntimeEnv>,
-    }
-
-    impl Int64ListExecCodec {
-        fn new(runtime: Arc<RuntimeEnv>) -> Self {
-            Self { runtime }
-        }
-    }
-
-    impl PhysicalExtensionCodecExt for Int64ListExecCodec {
-        fn try_decode(
-            &self,
-            buf: &[u8],
-            _: &[Arc<dyn ExecutionPlan>],
-            registry: &dyn FunctionRegistry,
-            codec: &dyn PhysicalExtensionCodec
-        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-            Int64ListExecProto::try_decode(buf)?.try_into_physical_plan(
-                registry,
-                &self.runtime,
-                codec,
-            )
-        }
-
-        fn try_encode(
-            &self,
-            node: Arc<dyn ExecutionPlan>,
-            buf: &mut Vec<u8>,
-            codec: &dyn PhysicalExtensionCodec
-        ) -> datafusion::common::Result<()> {
-            Int64ListExecProto::try_from_physical_plan(node, codec)?.try_encode(buf)
-        }
-    }
+    struct Int64ListExecCodec;
 
     #[derive(Clone, PartialEq, ::prost::Message)]
     struct Int64ListExecProto {
@@ -272,45 +235,34 @@ mod tests {
         numbers: Vec<i64>,
     }
 
-    impl AsExecutionPlan for Int64ListExecProto {
-        fn try_decode(buf: &[u8]) -> datafusion::common::Result<Self>
-        where
-            Self: Sized,
-        {
-            Int64ListExecProto::decode(buf).map_err(|err| proto_error(format!("{err}")))
-        }
-
-        fn try_encode<B>(&self, buf: &mut B) -> datafusion::common::Result<()>
-        where
-            B: BufMut,
-            Self: Sized,
-        {
-            self.encode(buf)
-                .map_err(|err| proto_error(format!("{err}")))
-        }
-
-        fn try_into_physical_plan(
+    impl PhysicalExtensionCodec for Int64ListExecCodec {
+        fn try_decode(
             &self,
-            _: &dyn FunctionRegistry,
-            _: &RuntimeEnv,
-            _: &dyn PhysicalExtensionCodec,
+            buf: &[u8],
+            _: &[Arc<dyn ExecutionPlan>],
+            _registry: &dyn FunctionRegistry,
         ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-            Ok(Arc::new(Int64ListExec::new(self.numbers.clone())))
+            let node =
+                Int64ListExecProto::decode(buf).map_err(|err| proto_error(format!("{err}")))?;
+            Ok(Arc::new(Int64ListExec::new(node.numbers.clone())))
         }
 
-        fn try_from_physical_plan(
-            plan: Arc<dyn ExecutionPlan>,
-            _: &dyn PhysicalExtensionCodec,
-        ) -> datafusion::common::Result<Self>
-        where
-            Self: Sized,
-        {
-            let Some(plan) = plan.as_any().downcast_ref::<Int64ListExec>() else {
-                return Err(proto_error(format!("Expected plan to be of type Int64ListExec, but was {}", plan.name())));
+        fn try_encode(
+            &self,
+            node: Arc<dyn ExecutionPlan>,
+            buf: &mut Vec<u8>,
+        ) -> datafusion::common::Result<()> {
+            let Some(plan) = node.as_any().downcast_ref::<Int64ListExec>() else {
+                return Err(proto_error(format!(
+                    "Expected plan to be of type Int64ListExec, but was {}",
+                    node.name()
+                )));
             };
-            Ok(Int64ListExecProto {
+            Int64ListExecProto {
                 numbers: plan.numbers.clone(),
-            })
+            }
+            .encode(buf)
+            .map_err(|err| proto_error(format!("{err}")))
         }
     }
 }

--- a/tests/custom_extension_codec.rs
+++ b/tests/custom_extension_codec.rs
@@ -1,0 +1,300 @@
+#[allow(dead_code)]
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use crate::common::localhost::start_localhost_context;
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::compute::SortOptions;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::arrow::util::pretty::pretty_format_batches;
+    use datafusion::error::DataFusionError;
+    use datafusion::execution::runtime_env::RuntimeEnv;
+    use datafusion::execution::{
+        FunctionRegistry, SendableRecordBatchStream, SessionStateBuilder, TaskContext,
+    };
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{col, lit, BinaryExpr};
+    use datafusion::physical_expr::{
+        EquivalenceProperties, LexOrdering, Partitioning, PhysicalSortExpr,
+    };
+    use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+    use datafusion::physical_plan::filter::FilterExec;
+    use datafusion::physical_plan::sorts::sort::SortExec;
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use datafusion::physical_plan::{displayable, execute_stream, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+    use datafusion_distributed_experiment::{ArrowFlightReadExec, PhysicalExtensionCodecExt, SessionBuilder};
+    use datafusion_proto::physical_plan::{AsExecutionPlan, PhysicalExtensionCodec};
+    use datafusion_proto::protobuf::proto_error;
+    use futures::{stream, TryStreamExt};
+    use insta::assert_snapshot;
+    use prost::bytes::BufMut;
+    use prost::Message;
+    use std::any::Any;
+    use std::fmt::Formatter;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn custom_extension_codec() -> Result<(), Box<dyn std::error::Error>> {
+        fn build_plan(distributed: bool) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+            let mut plan: Arc<dyn ExecutionPlan> =
+                Arc::new(Int64ListExec::new(vec![1, 2, 3, 4, 5, 6]));
+
+            plan = Arc::new(FilterExec::try_new(
+                Arc::new(BinaryExpr::new(
+                    col("numbers", &plan.schema())?,
+                    Operator::Gt,
+                    lit(1i64),
+                )),
+                plan,
+            )?);
+
+            if distributed {
+                plan = Arc::new(ArrowFlightReadExec::new(
+                    plan.clone(),
+                    Partitioning::Hash(vec![col("numbers", &plan.schema())?], 1),
+                ));
+            }
+
+            plan = Arc::new(SortExec::new(
+                LexOrdering::new(vec![PhysicalSortExpr::new(
+                    col("numbers", &plan.schema())?,
+                    SortOptions::new(true, false),
+                )]),
+                plan,
+            ));
+
+            if distributed {
+                plan = Arc::new(ArrowFlightReadExec::new(
+                    plan.clone(),
+                    Partitioning::RoundRobinBatch(10),
+                ));
+            }
+
+            Ok(plan)
+        }
+
+        #[derive(Clone)]
+        struct CustomSessionBuilder;
+        impl SessionBuilder for CustomSessionBuilder {
+            fn on_new_session(&self, mut builder: SessionStateBuilder) -> SessionStateBuilder {
+                let runtime_env = builder.runtime_env().get_or_insert_default();
+                let codec: Arc<dyn PhysicalExtensionCodecExt> =
+                    Arc::new(Int64ListExecCodec::new(runtime_env.clone()));
+                let config = builder.config().get_or_insert_default();
+                config.set_extension(Arc::new(codec));
+                builder
+            }
+        }
+
+        let (ctx, _guard) =
+            start_localhost_context([50050, 50051, 50052], CustomSessionBuilder).await;
+
+        let codec: Arc<dyn PhysicalExtensionCodecExt> =
+            Arc::new(Int64ListExecCodec::new(ctx.runtime_env()));
+        ctx.state_ref()
+            .write()
+            .config_mut()
+            .set_extension(Arc::new(codec));
+
+        let single_node_plan = build_plan(false)?;
+        assert_snapshot!(displayable(single_node_plan.as_ref()).indent(true).to_string(), @r"
+        SortExec: expr=[numbers@0 DESC NULLS LAST], preserve_partitioning=[false]
+          FilterExec: numbers@0 > 1
+            Int64ListExec: length=6
+        ");
+
+        let distributed_plan = build_plan(true)?;
+
+        assert_snapshot!(displayable(distributed_plan.as_ref()).indent(true).to_string(), @r"
+        ArrowFlightReadExec: input_actors=10
+          SortExec: expr=[numbers@0 DESC NULLS LAST], preserve_partitioning=[false]
+            ArrowFlightReadExec: input_actors=1 hash=[numbers@0]
+              FilterExec: numbers@0 > 1
+                Int64ListExec: length=6
+        ");
+
+        let stream = execute_stream(single_node_plan, ctx.task_ctx())?;
+        let batches_single_node = stream.try_collect::<Vec<_>>().await?;
+
+        assert_snapshot!(pretty_format_batches(&batches_single_node)?, @r"
+        +---------+
+        | numbers |
+        +---------+
+        | 6       |
+        | 5       |
+        | 4       |
+        | 3       |
+        | 2       |
+        +---------+
+        ");
+
+        let stream = execute_stream(distributed_plan, ctx.task_ctx())?;
+        let batches_distributed = stream.try_collect::<Vec<_>>().await?;
+
+        assert_snapshot!(pretty_format_batches(&batches_distributed)?, @r"
+        +---------+
+        | numbers |
+        +---------+
+        | 6       |
+        | 5       |
+        | 4       |
+        | 3       |
+        | 2       |
+        +---------+
+        ");
+        Ok(())
+    }
+
+    #[derive(Debug)]
+    pub struct Int64ListExec {
+        plan_properties: PlanProperties,
+        numbers: Vec<i64>,
+    }
+
+    impl Int64ListExec {
+        fn new(numbers: Vec<i64>) -> Self {
+            let schema = Schema::new(vec![Field::new("numbers", DataType::Int64, false)]);
+            Self {
+                numbers,
+                plan_properties: PlanProperties::new(
+                    EquivalenceProperties::new(Arc::new(schema)),
+                    Partitioning::UnknownPartitioning(1),
+                    EmissionType::Incremental,
+                    Boundedness::Bounded,
+                ),
+            }
+        }
+    }
+
+    impl DisplayAs for Int64ListExec {
+        fn fmt_as(&self, _: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+            write!(f, "Int64ListExec: length={:?}", self.numbers.len())
+        }
+    }
+
+    impl ExecutionPlan for Int64ListExec {
+        fn name(&self) -> &str {
+            "Int64ListExec"
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn properties(&self) -> &PlanProperties {
+            &self.plan_properties
+        }
+
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+
+        fn with_new_children(
+            self: Arc<Self>,
+            _: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+            Ok(self)
+        }
+
+        fn execute(
+            &self,
+            _: usize,
+            _: Arc<TaskContext>,
+        ) -> datafusion::common::Result<SendableRecordBatchStream> {
+            let array = Int64Array::from(self.numbers.clone());
+            let batch = RecordBatch::try_new(self.schema(), vec![Arc::new(array)])?;
+
+            let stream = stream::iter(vec![Ok(batch)]);
+            Ok(Box::pin(RecordBatchStreamAdapter::new(
+                self.schema(),
+                stream,
+            )))
+        }
+    }
+
+    #[derive(Debug)]
+    struct Int64ListExecCodec {
+        runtime: Arc<RuntimeEnv>,
+    }
+
+    impl Int64ListExecCodec {
+        fn new(runtime: Arc<RuntimeEnv>) -> Self {
+            Self { runtime }
+        }
+    }
+
+    impl PhysicalExtensionCodecExt for Int64ListExecCodec {
+        fn try_decode(
+            &self,
+            buf: &[u8],
+            _: &[Arc<dyn ExecutionPlan>],
+            registry: &dyn FunctionRegistry,
+            codec: &dyn PhysicalExtensionCodec
+        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+            Int64ListExecProto::try_decode(buf)?.try_into_physical_plan(
+                registry,
+                &self.runtime,
+                codec,
+            )
+        }
+
+        fn try_encode(
+            &self,
+            node: Arc<dyn ExecutionPlan>,
+            buf: &mut Vec<u8>,
+            codec: &dyn PhysicalExtensionCodec
+        ) -> datafusion::common::Result<()> {
+            Int64ListExecProto::try_from_physical_plan(node, codec)?.try_encode(buf)
+        }
+    }
+
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    struct Int64ListExecProto {
+        #[prost(message, repeated, tag = "1")]
+        numbers: Vec<i64>,
+    }
+
+    impl AsExecutionPlan for Int64ListExecProto {
+        fn try_decode(buf: &[u8]) -> datafusion::common::Result<Self>
+        where
+            Self: Sized,
+        {
+            Int64ListExecProto::decode(buf).map_err(|err| proto_error(format!("{err}")))
+        }
+
+        fn try_encode<B>(&self, buf: &mut B) -> datafusion::common::Result<()>
+        where
+            B: BufMut,
+            Self: Sized,
+        {
+            self.encode(buf)
+                .map_err(|err| proto_error(format!("{err}")))
+        }
+
+        fn try_into_physical_plan(
+            &self,
+            _: &dyn FunctionRegistry,
+            _: &RuntimeEnv,
+            _: &dyn PhysicalExtensionCodec,
+        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+            Ok(Arc::new(Int64ListExec::new(self.numbers.clone())))
+        }
+
+        fn try_from_physical_plan(
+            plan: Arc<dyn ExecutionPlan>,
+            _: &dyn PhysicalExtensionCodec,
+        ) -> datafusion::common::Result<Self>
+        where
+            Self: Sized,
+        {
+            let Some(plan) = plan.as_any().downcast_ref::<Int64ListExec>() else {
+                return Err(proto_error(format!("Expected plan to be of type Int64ListExec, but was {}", plan.name())));
+            };
+            Ok(Int64ListExecProto {
+                numbers: plan.numbers.clone(),
+            })
+        }
+    }
+}

--- a/tests/distributed_aggregation.rs
+++ b/tests/distributed_aggregation.rs
@@ -3,7 +3,7 @@ mod common;
 #[cfg(test)]
 mod tests {
     use crate::assert_snapshot;
-    use crate::common::localhost::start_localhost_context;
+    use crate::common::localhost::{start_localhost_context, NoopSessionBuilder};
     use crate::common::parquet::register_parquet_tables;
     use crate::common::plan::distribute_aggregate;
     use datafusion::arrow::util::pretty::pretty_format_batches;
@@ -13,7 +13,8 @@ mod tests {
 
     #[tokio::test]
     async fn distributed_aggregation() -> Result<(), Box<dyn Error>> {
-        let (ctx, _guard) = start_localhost_context([50050, 50051, 50052]).await;
+        let (ctx, _guard) =
+            start_localhost_context([50050, 50051, 50052], NoopSessionBuilder).await;
         register_parquet_tables(&ctx).await?;
 
         let df = ctx

--- a/tests/highly_distributed_query.rs
+++ b/tests/highly_distributed_query.rs
@@ -3,7 +3,7 @@ mod common;
 #[cfg(test)]
 mod tests {
     use crate::assert_snapshot;
-    use crate::common::localhost::start_localhost_context;
+    use crate::common::localhost::{start_localhost_context, NoopSessionBuilder};
     use crate::common::parquet::register_parquet_tables;
     use datafusion::physical_expr::Partitioning;
     use datafusion::physical_plan::{displayable, execute_stream};
@@ -16,7 +16,7 @@ mod tests {
     async fn highly_distributed_query() -> Result<(), Box<dyn Error>> {
         let (ctx, _guard) = start_localhost_context([
             50050, 50051, 50053, 50054, 50055, 50056, 50057, 50058, 50059,
-        ])
+        ], NoopSessionBuilder)
         .await;
         register_parquet_tables(&ctx).await?;
 


### PR DESCRIPTION
Users of this library might have their own proto extensions that will need to be serialized and sent over the wire between tasks.

This PR adds support for adding new codecs along with the ones the project already has built-in.


There was one complication though:

DataFusion's API for implementing `PhysicalExtensionCodec` is designed towards having just one `PhysicalExtensionCodec`, and this results in a chain of events that might result in the incapability of serializing certain plans:
1. A user has their own `ExecutionPlan` node, for which they want to implement proto serialization
2. They create a new `MyNodeExecCodec` for encoding/decoding this node from protobuf
3. This `MyNodeExecCodec` can have an arbitrary number of children, so encoding/decoding this node, also implies encoding/decoding its children
4. In order to encode/decode the children, a `PhysicalExtensionCodec` needs to be passed to the `try_from_physical_plan` and `try_into_physical_plan` methods from `AsExecutionPlan`.
5. The only codec available in that moment is the user's `MyNodeExecCodec`, but our own distributed-datafusion specific codes also need to be passed.
6. The encoding/decoding fails on child nodes, as at some point, some of the children of `MyNodeExec` might be our `ArrowFlightReadExec`, and `MyNodeExecCodec` does not know how to handle that

The way this is solved is by introducing an intermediate trait `PhysicalExtensionCodecExt`, which accepts an additional last argument in all it's methods: `codec: &dyn PhysicalExtensionCodec`. This project will make sure that whatever codec is passed there is capable of decoding not only the user's custom node, but also this project's custom nodes (just `ArrowFlightReadExec`)